### PR TITLE
Add EU cookie disclaimer

### DIFF
--- a/src/header.ts
+++ b/src/header.ts
@@ -99,6 +99,11 @@ export interface IAppHeaderOptions {
    * default: true
    */
   showReportBugLink?: boolean;
+
+  /**
+   * show/hide the EU cookie disclaimer bar from `cookie-bar.eu`
+   */
+  showCookieDisclaimer?: boolean;
 }
 
 /**
@@ -154,7 +159,12 @@ export class AppHeader {
     /**
      * show/hide the bug report link
      */
-    showReportBugLink: true
+    showReportBugLink: true,
+
+    /**
+     * show/hide the EU cookie disclaimer bar from `cookie-bar.eu`
+     */
+    showCookieDisclaimer: false
   };
 
   /**
@@ -189,6 +199,10 @@ export class AppHeader {
   }
 
   private addEUCookieDisclaimer() {
+    if(!this.options.showCookieDisclaimer) {
+      return;
+    }
+
     const script = document.createElement('script');
     script.type = 'text/javascript';
     script.async = true;

--- a/src/header.ts
+++ b/src/header.ts
@@ -11,6 +11,11 @@ import lazyBootstrap from './_lazyBootstrap';
 import buildBuildInfo from './buildInfo';
 import getMetaData from './metaData';
 
+
+// declare the function name of the `cookie-bar` for the TS compiler (see addEUCookieDisclaimer())
+declare var setupCookieBar: any;
+
+
 /**
  * Defines a header link
  */
@@ -179,7 +184,19 @@ export class AppHeader {
    */
   constructor(private parent: HTMLElement, options: IAppHeaderOptions = {}) {
     mixin(this.options, options);
+    this.addEUCookieDisclaimer();
     this.build();
+  }
+
+  private addEUCookieDisclaimer() {
+    const script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = 'https://cdn.jsdelivr.net/npm/cookie-bar/cookiebar-latest.min.js?theme=flying';
+    script.onload = () => {
+      setupCookieBar();
+    };
+    this.parent.ownerDocument.body.appendChild(script);
   }
 
   private async build() {


### PR DESCRIPTION
Related issue #29.

Implemented using the https://cookie-bar.eu/

![image](https://user-images.githubusercontent.com/5851088/34492087-60a056a2-efe6-11e7-8a90-1319ca1f0255.png)

To show the cookie disclaimer activate the flag in the phovea header:

```ts
import {create as createHeader, IAppHeaderOptions} from 'phovea_ui/src/header';

// ...

const headerOptions:IAppHeaderOptions = {
  showCookieDisclaimer: true
};
const header = createHeader(<HTMLElement>body.querySelector('div.main'), headerOptions);
```

  