### PR TITLE
Fix slim header when page has scrollbars

### DIFF
--- a/src/styles/_header_navbar.scss
+++ b/src/styles/_header_navbar.scss
@@ -4,7 +4,7 @@
 nav.navbar,
 nav.navbar-inverse {
   margin: 0;
-  min-height: 28px;
+  min-height: auto;
   border-radius: 0;
   border: none;
   border-bottom: 2px solid;


### PR DESCRIPTION
Fixes #68

@dvmichaelpuehringer Thanks for your suggestion! I fixed it using the `min-height: auto`.

![fix-slim-header](https://user-images.githubusercontent.com/5851088/64787078-37c19e00-d570-11e9-9444-8fece3c2ace3.gif)
