### PR TITLE
Make the styles of dark theme of the phovea header more specific

### DIFF
--- a/dist/components/header.js
+++ b/dist/components/header.js
@@ -9,7 +9,7 @@ import { AppMetaDataUtils } from './metaData';
  * header html template declared inline so we can use i18next
  */
 const getTemplate = () => {
-    return (`<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    return (`<nav class="navbar phovea-navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#" data-header="appLink"></a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#headerNavBar" aria-controls="headerNavBar" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/dist/scss/abstracts/_variables.scss
+++ b/dist/scss/abstracts/_variables.scss
@@ -1,11 +1,12 @@
-
 $fa-font-path: '~@fortawesome/fontawesome-free/webfonts' !default;
 // $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/' !default; // Bootstrap v3
 
 // Override and set Bootstrap theme colors
 // @see https://getbootstrap.com/docs/4.5/getting-started/theming/#sass-options
 // @usage `color: map-get($theme-colors, "light");`
-$theme-colors: (
+$theme-colors: () !default; // define empty $theme-colors map first to merge other colors later
+
+$phovea-theme-colors: (
   "light": #F1F2F4,
   "dark": #2F353A,
   "white": #FFFFFF,
@@ -15,8 +16,9 @@ $theme-colors: (
   "gray-3":  #d4d7dd,
   "gray-4":  #aab3bb,
   "gray-5":  #3b4349,
-); // TODO: change imports to use !default here and allow overriding
+) !default;
 
+$theme-colors: map-merge($theme-colors, $phovea-theme-colors);
 
 $phovea-loading-icon-url: url('~phovea_ui/dist/assets/caleydo_c_anim.svg') !default;
 $phovea-loading-icon-background: rgba(255, 255, 255, 0.26) #{$phovea-loading-icon-url} no-repeat fixed center !default;

--- a/dist/scss/components/_header_navbar.scss
+++ b/dist/scss/components/_header_navbar.scss
@@ -31,8 +31,8 @@
 
 .phovea-navbar {
   /**
- * Colors light theme
- */
+   * Colors light theme
+   */
   &.navbar-light {
     border-bottom: 1px solid map-get($theme-colors, "gray-3");
 
@@ -57,8 +57,8 @@
   }
 
   /**
- * Colors dark theme
- */
+   * Colors dark theme
+   */
   &.navbar-dark {
     border-bottom-color: map-get($theme-colors, "gray-5");
 

--- a/dist/scss/components/_header_navbar.scss
+++ b/dist/scss/components/_header_navbar.scss
@@ -29,55 +29,57 @@
   }
 }
 
-/**
+.phovea-navbar {
+  /**
  * Colors light theme
  */
-.navbar-light {
-  border-bottom: 1px solid map-get($theme-colors, "gray-3");
+  &.navbar-light {
+    border-bottom: 1px solid map-get($theme-colors, "gray-3");
 
-  .navbar-brand {
-    color: map-get($theme-colors, "dark");
-  }
+    .navbar-brand {
+      color: map-get($theme-colors, "dark");
+    }
 
-  .nav-link {
-    color: map-get($theme-colors, "dark");
+    .nav-link {
+      color: map-get($theme-colors, "dark");
 
-    &:hover,
-    &:focus {
+      &:hover,
+      &:focus {
+        background-color: map-get($theme-colors, "gray-3");
+        color: map-get($theme-colors, "dark");
+      }
+    }
+
+    .active > .nav-link {
       background-color: map-get($theme-colors, "gray-3");
       color: map-get($theme-colors, "dark");
     }
   }
 
-  .active > .nav-link {
-    background-color: map-get($theme-colors, "gray-3");
-    color: map-get($theme-colors, "dark");
-  }
-}
-
-/**
+  /**
  * Colors dark theme
  */
-.navbar-dark {
-  border-bottom-color: map-get($theme-colors, "gray-5");
+  &.navbar-dark {
+    border-bottom-color: map-get($theme-colors, "gray-5");
 
-  .navbar-brand {
-    color: map-get($theme-colors, "white");
-  }
+    .navbar-brand {
+      color: map-get($theme-colors, "white");
+    }
 
-  .nav-link {
-    color: map-get($theme-colors, "light");
+    .nav-link {
+      color: map-get($theme-colors, "light");
 
-    &:hover,
-    &:focus {
+      &:hover,
+      &:focus {
+        background-color: map-get($theme-colors, "light");
+        color: map-get($theme-colors, "dark");
+      }
+    }
+
+    .active > .nav-link {
       background-color: map-get($theme-colors, "light");
       color: map-get($theme-colors, "dark");
     }
-  }
-
-  .active > .nav-link {
-    background-color: map-get($theme-colors, "light");
-    color: map-get($theme-colors, "dark");
   }
 }
 
@@ -95,7 +97,7 @@
 
     &::before {
       display: block;
-      content: '';
+      content: "";
       background: transparent #{$phovea-brand-logo-url} no-repeat top center;
       background-size: contain;
       flex-basis: $phovea-brand-logo-width;

--- a/src/components/header.ts
+++ b/src/components/header.ts
@@ -12,7 +12,7 @@ import {AppMetaDataUtils} from './metaData';
  * header html template declared inline so we can use i18next
  */
 const getTemplate = () => {
-  return (`<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  return (`<nav class="navbar phovea-navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#" data-header="appLink"></a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#headerNavBar" aria-controls="headerNavBar" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -1,11 +1,12 @@
-
 $fa-font-path: '~@fortawesome/fontawesome-free/webfonts' !default;
 // $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/' !default; // Bootstrap v3
 
 // Override and set Bootstrap theme colors
 // @see https://getbootstrap.com/docs/4.5/getting-started/theming/#sass-options
 // @usage `color: map-get($theme-colors, "light");`
-$theme-colors: (
+$theme-colors: () !default; // define empty $theme-colors map first to merge other colors later
+
+$phovea-theme-colors: (
   "light": #F1F2F4,
   "dark": #2F353A,
   "white": #FFFFFF,
@@ -15,8 +16,9 @@ $theme-colors: (
   "gray-3":  #d4d7dd,
   "gray-4":  #aab3bb,
   "gray-5":  #3b4349,
-); // TODO: change imports to use !default here and allow overriding
+) !default;
 
+$theme-colors: map-merge($theme-colors, $phovea-theme-colors);
 
 $phovea-loading-icon-url: url('~phovea_ui/dist/assets/caleydo_c_anim.svg') !default;
 $phovea-loading-icon-background: rgba(255, 255, 255, 0.26) #{$phovea-loading-icon-url} no-repeat fixed center !default;

--- a/src/scss/components/_header_navbar.scss
+++ b/src/scss/components/_header_navbar.scss
@@ -31,8 +31,8 @@
 
 .phovea-navbar {
   /**
- * Colors light theme
- */
+   * Colors light theme
+   */
   &.navbar-light {
     border-bottom: 1px solid map-get($theme-colors, "gray-3");
 
@@ -57,8 +57,8 @@
   }
 
   /**
- * Colors dark theme
- */
+   * Colors dark theme
+   */
   &.navbar-dark {
     border-bottom-color: map-get($theme-colors, "gray-5");
 

--- a/src/scss/components/_header_navbar.scss
+++ b/src/scss/components/_header_navbar.scss
@@ -29,55 +29,57 @@
   }
 }
 
-/**
+.phovea-navbar {
+  /**
  * Colors light theme
  */
-.navbar-light {
-  border-bottom: 1px solid map-get($theme-colors, "gray-3");
+  &.navbar-light {
+    border-bottom: 1px solid map-get($theme-colors, "gray-3");
 
-  .navbar-brand {
-    color: map-get($theme-colors, "dark");
-  }
+    .navbar-brand {
+      color: map-get($theme-colors, "dark");
+    }
 
-  .nav-link {
-    color: map-get($theme-colors, "dark");
+    .nav-link {
+      color: map-get($theme-colors, "dark");
 
-    &:hover,
-    &:focus {
+      &:hover,
+      &:focus {
+        background-color: map-get($theme-colors, "gray-3");
+        color: map-get($theme-colors, "dark");
+      }
+    }
+
+    .active > .nav-link {
       background-color: map-get($theme-colors, "gray-3");
       color: map-get($theme-colors, "dark");
     }
   }
 
-  .active > .nav-link {
-    background-color: map-get($theme-colors, "gray-3");
-    color: map-get($theme-colors, "dark");
-  }
-}
-
-/**
+  /**
  * Colors dark theme
  */
-.navbar-dark {
-  border-bottom-color: map-get($theme-colors, "gray-5");
+  &.navbar-dark {
+    border-bottom-color: map-get($theme-colors, "gray-5");
 
-  .navbar-brand {
-    color: map-get($theme-colors, "white");
-  }
+    .navbar-brand {
+      color: map-get($theme-colors, "white");
+    }
 
-  .nav-link {
-    color: map-get($theme-colors, "light");
+    .nav-link {
+      color: map-get($theme-colors, "light");
 
-    &:hover,
-    &:focus {
+      &:hover,
+      &:focus {
+        background-color: map-get($theme-colors, "light");
+        color: map-get($theme-colors, "dark");
+      }
+    }
+
+    .active > .nav-link {
       background-color: map-get($theme-colors, "light");
       color: map-get($theme-colors, "dark");
     }
-  }
-
-  .active > .nav-link {
-    background-color: map-get($theme-colors, "light");
-    color: map-get($theme-colors, "dark");
   }
 }
 
@@ -95,7 +97,7 @@
 
     &::before {
       display: block;
-      content: '';
+      content: "";
       background: transparent #{$phovea-brand-logo-url} no-repeat top center;
       background-size: contain;
       flex-basis: $phovea-brand-logo-width;


### PR DESCRIPTION
When you import all styles in welcome.scss, the styles of the phovea header affect those of the welcome page `Navigation`

https://github.com/phovea/phovea_ui/blob/4511e48ab31d10e746127405769d8b4d41f97030/src/scss/components/_header_navbar.scss#L61-L82

![grafik](https://user-images.githubusercontent.com/51322092/111599950-272b5d00-87d1-11eb-8fc2-39b0f20a13f9.gif)


### Summary 
* Added an additional css class to the header template to make the styles more specific (feel free to suggest a better class name)