### PR TITLE
Fix SASS `$theme-color` assignment

### DIFF
--- a/dist/scss/abstracts/_variables.scss
+++ b/dist/scss/abstracts/_variables.scss
@@ -1,11 +1,12 @@
-
 $fa-font-path: '~@fortawesome/fontawesome-free/webfonts' !default;
 // $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/' !default; // Bootstrap v3
 
 // Override and set Bootstrap theme colors
 // @see https://getbootstrap.com/docs/4.5/getting-started/theming/#sass-options
 // @usage `color: map-get($theme-colors, "light");`
-$theme-colors: (
+$theme-colors: () !default; // define empty $theme-colors map first to merge other colors later
+
+$phovea-theme-colors: (
   "light": #F1F2F4,
   "dark": #2F353A,
   "white": #FFFFFF,
@@ -15,8 +16,9 @@ $theme-colors: (
   "gray-3":  #d4d7dd,
   "gray-4":  #aab3bb,
   "gray-5":  #3b4349,
-); // TODO: change imports to use !default here and allow overriding
+) !default;
 
+$theme-colors: map-merge($theme-colors, $phovea-theme-colors);
 
 $phovea-loading-icon-url: url('~phovea_ui/dist/assets/caleydo_c_anim.svg') !default;
 $phovea-loading-icon-background: rgba(255, 255, 255, 0.26) #{$phovea-loading-icon-url} no-repeat fixed center !default;

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -1,11 +1,12 @@
-
 $fa-font-path: '~@fortawesome/fontawesome-free/webfonts' !default;
 // $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/' !default; // Bootstrap v3
 
 // Override and set Bootstrap theme colors
 // @see https://getbootstrap.com/docs/4.5/getting-started/theming/#sass-options
 // @usage `color: map-get($theme-colors, "light");`
-$theme-colors: (
+$theme-colors: () !default; // define empty $theme-colors map first to merge other colors later
+
+$phovea-theme-colors: (
   "light": #F1F2F4,
   "dark": #2F353A,
   "white": #FFFFFF,
@@ -15,8 +16,9 @@ $theme-colors: (
   "gray-3":  #d4d7dd,
   "gray-4":  #aab3bb,
   "gray-5":  #3b4349,
-); // TODO: change imports to use !default here and allow overriding
+) !default;
 
+$theme-colors: map-merge($theme-colors, $phovea-theme-colors);
 
 $phovea-loading-icon-url: url('~phovea_ui/dist/assets/caleydo_c_anim.svg') !default;
 $phovea-loading-icon-background: rgba(255, 255, 255, 0.26) #{$phovea-loading-icon-url} no-repeat fixed center !default;


### PR DESCRIPTION
### Summary

* Previously, the `$theme-color` was set as [suggested in the BS documentation](https://getbootstrap.com/docs/4.5/getting-started/theming/#sass-options)
* Problem: Colors could not be overriden by other repositories and `!default` did not work
* This PR creates an empty `$theme-colors` map (if not available = `!default`) and merges them with custom colors  of an additional map
* The colors can then be overriden later in other repos