### PR TITLE
Add dark theme colors and adapt navbar links

### DIFF
--- a/dist/scss/abstracts/_variables.scss
+++ b/dist/scss/abstracts/_variables.scss
@@ -16,6 +16,8 @@ $phovea-theme-colors: (
   "gray-3":  #d4d7dd,
   "gray-4":  #aab3bb,
   "gray-5":  #3b4349,
+  "gray-6":  #5c6873,
+  "gray-7":  #73818f,
 ) !default;
 
 $theme-colors: map-merge($theme-colors, $phovea-theme-colors);

--- a/dist/scss/components/_header_navbar.scss
+++ b/dist/scss/components/_header_navbar.scss
@@ -71,8 +71,8 @@
 
       &:hover,
       &:focus {
-        background-color: map-get($theme-colors, "light");
-        color: map-get($theme-colors, "dark");
+        background-color: map-get($theme-colors, "gray-6");
+        color: map-get($theme-colors, "light");
       }
     }
 

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -16,6 +16,8 @@ $phovea-theme-colors: (
   "gray-3":  #d4d7dd,
   "gray-4":  #aab3bb,
   "gray-5":  #3b4349,
+  "gray-6":  #5c6873,
+  "gray-7":  #73818f,
 ) !default;
 
 $theme-colors: map-merge($theme-colors, $phovea-theme-colors);

--- a/src/scss/components/_header_navbar.scss
+++ b/src/scss/components/_header_navbar.scss
@@ -71,8 +71,8 @@
 
       &:hover,
       &:focus {
-        background-color: map-get($theme-colors, "light");
-        color: map-get($theme-colors, "dark");
+        background-color: map-get($theme-colors, "gray-6");
+        color: map-get($theme-colors, "light");
       }
     }
 


### PR DESCRIPTION
https://github.com/datavisyn/visyn2025/issues/89

### Summary

* Add dark theme colors for navbar links

Normal

![grafik](https://user-images.githubusercontent.com/5851088/121042108-a8343800-c7b3-11eb-946b-6badb5338e3d.png)

Hover/focus

![grafik](https://user-images.githubusercontent.com/5851088/121042181-b71aea80-c7b3-11eb-8c78-5678d537987f.png)

Active class

![grafik](https://user-images.githubusercontent.com/5851088/121042261-cac65100-c7b3-11eb-926c-cc0bf94fc025.png)


To do for later: We should try to refactor the gray colors, as they are getting a lot.
