### PR TITLE
Add `.hover` class to navbar for TDP tours

### DIFF
--- a/dist/scss/components/_header_navbar.scss
+++ b/dist/scss/components/_header_navbar.scss
@@ -44,7 +44,8 @@
       color: map-get($theme-colors, "dark");
 
       &:hover,
-      &:focus {
+      &:focus,
+      &.hover { // add .hover class to set state programmatically from TDP tours
         background-color: map-get($theme-colors, "gray-3");
         color: map-get($theme-colors, "dark");
       }
@@ -69,8 +70,10 @@
     .nav-link {
       color: map-get($theme-colors, "light");
 
+      &:active,
       &:hover,
-      &:focus {
+      &:focus,
+      &.hover { // add .hover class to set state programmatically from TDP tours
         background-color: map-get($theme-colors, "gray-6");
         color: map-get($theme-colors, "light");
       }

--- a/src/scss/components/_header_navbar.scss
+++ b/src/scss/components/_header_navbar.scss
@@ -44,7 +44,8 @@
       color: map-get($theme-colors, "dark");
 
       &:hover,
-      &:focus {
+      &:focus,
+      &.hover { // add .hover class to set state programmatically from TDP tours
         background-color: map-get($theme-colors, "gray-3");
         color: map-get($theme-colors, "dark");
       }
@@ -69,8 +70,10 @@
     .nav-link {
       color: map-get($theme-colors, "light");
 
+      &:active,
       &:hover,
-      &:focus {
+      &:focus,
+      &.hover { // add .hover class to set state programmatically from TDP tours
         background-color: map-get($theme-colors, "gray-6");
         color: map-get($theme-colors, "light");
       }


### PR DESCRIPTION
### Summary

* Add `.hover` class to `nav-link` in navbar to set state programmatically from TDP tours